### PR TITLE
Make original plots always use multi-plot layout

### DIFF
--- a/zppy_interfaces/global_time_series/coupled_global.py
+++ b/zppy_interfaces/global_time_series/coupled_global.py
@@ -332,11 +332,17 @@ def coupled_global(parameters: Parameters) -> None:
         # In this case, we don't want the summary PDF.
         # Rather, we want to construct a viewer similar to E3SM Diags.
         title_and_url_list: List[Tuple[str, str]] = []
-        for component in ["original", "atm", "ice", "lnd", "ocn"]:
+        for component in ["atm", "ice", "lnd", "ocn"]:  # Don't create viewer for original component
             vars = get_vars(requested_variables, component)
             if vars:
                 url = create_viewer(parameters, vars, component)
                 logger.info(f"Viewer URL for {component}: {url}")
                 title_and_url_list.append((component, url))
+        # Special case for original - these are always multi-plot PDFs
+        vars = get_vars(requested_variables, "original")
+        if vars:
+            logger.info("Original plots will be in multi-plot PDF format")
+            title_and_url_list.append(("original", f"{parameters.results_dir}/{parameters.figstr}_glb_original.pdf"))
+        
         index_url: str = create_viewer_index(parameters.results_dir, title_and_url_list)
         logger.info(f"Viewer index URL: {index_url}")

--- a/zppy_interfaces/global_time_series/coupled_global_plotting.py
+++ b/zppy_interfaces/global_time_series/coupled_global_plotting.py
@@ -554,7 +554,16 @@ def make_plot_pdfs(  # noqa: C901
     num_plots = len(plot_list)
     if num_plots == 0:
         return
-    plots_per_page = parameters.nrows * parameters.ncols
+    
+    # For original plots, always use multiple plots per page regardless of make_viewer setting
+    use_multi_plot = not parameters.make_viewer or component == "original"
+    
+    # Determine layout based on whether we're using multi-plot or single-plot mode
+    if use_multi_plot:
+        plots_per_page = parameters.nrows * parameters.ncols
+    else:
+        plots_per_page = 1  # For viewer mode, one plot per page
+    
     num_pages = math.ceil(num_plots / plots_per_page)
 
     counter = 0
@@ -573,7 +582,9 @@ def make_plot_pdfs(  # noqa: C901
             # The final page doesn't need to be filled out with plots.
             if counter >= num_plots:
                 break
-            ax = plt.subplot(parameters.nrows, parameters.ncols, j + 1)
+            ax = plt.subplot(parameters.nrows if use_multi_plot else 1, 
+                            parameters.ncols if use_multi_plot else 1, 
+                            j + 1)
             if component == "original":
                 try:
                     plot_function = PLOT_DICT[plot_list[counter]]
@@ -616,6 +627,7 @@ def make_plot_pdfs(  # noqa: C901
 
         fig.tight_layout()
         pdf.savefig(1)
+        # Always save individual PNGs for viewer mode
         if plots_per_page == 1:
             fig.savefig(
                 f"{parameters.results_dir}/{parameters.figstr}_{rgn}_{component}_{plot_name}.png",

--- a/zppy_interfaces/global_time_series/utils.py
+++ b/zppy_interfaces/global_time_series/utils.py
@@ -39,6 +39,8 @@ class Parameters(object):
             raise RuntimeError(
                 f"make_viewer requires 1x1 plots, but nrows={self.nrows} and ncols={self.ncols}"
             )
+        # For "original" plots, always use multiple plots per page regardless of make_viewer setting
+        self.original_plots_multi: bool = True
 
         # For both
         self.year1: int = int(args["start_yr"])


### PR DESCRIPTION
- Add original_plots_multi flag to Parameters class
- Modify make_plot_pdfs to use multi-plot layout for original plots
- Change coupled_global to exclude original plots from interactive viewer
- Add special handling for original plots in index page

Now when make_viewer=True:
- Regular component plots use interactive viewer
- Original plots are always displayed as multi-plot PDFs
- Index page includes links to both interactive viewers and PDF files

🤖 Generated with [Claude Code](https://claude.ai/code)

## Summary

Objectives:
- Objective 1
- Objective 2
- ...
- Objective n

Issue resolution:
- Closes #<ISSUE_NUMBER_HERE>

Select one: This pull request is...
- [ ] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

Please fill out either the "Small Change" or "Big Change" section (the latter includes the numbered subsections), and delete the other.

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [ ] Logic: I have visually inspected the entire pull request myself.
- [ ] Pre-commit checks: All the pre-commits checks have passed.

## Big Change

- [ ] To merge, I will use "Create a merge commit". That is, this change is large enough to require multiple units of work (i.e., it should be multiple commits).

### 1. Does this do what we want it to do?

Required:
- [ ] Product Management: I have confirmed with the stakeholders that the objectives above are correct and complete.
- [ ] Testing: I have considered likely and/or severe edge cases and have included them in testing.

### 2. Are the implementation details accurate & efficient?

Required:
- [ ] Logic: I have visually inspected the entire pull request myself.
- [ ] Logic: I have left GitHub comments highlighting important pieces of code logic. I have had these code blocks reviewed by at least one other team member.

If applicable:
- [ ] Dependencies: This pull request introduces a new dependency. I have discussed this requirement with at least one other team member. The dependency is noted in `zppy-interfaces/conda`, not just an `import` statement.

### 3. Is this well documented?

Required:
- [ ] Documentation: by looking at the docs, a new user could easily understand the functionality introduced by this pull request.

### 4. Is this code clean?

Required:
- [ ] Readability: The code is as simple as possible and well-commented, such that a new team member could understand what's happening.
- [ ] Pre-commit checks: All the pre-commits checks have passed.

If applicable:
- [ ] Software architecture: I have discussed relevant trade-offs in design decisions with at least one other team member. It is unlikely that this pull request will increase tech debt.
