### PR TITLE
Comment out docs build

### DIFF
--- a/.github/workflows/build_workflow.yml
+++ b/.github/workflows/build_workflow.yml
@@ -113,75 +113,75 @@ jobs:
           pytest tests/unit/global_time_series/test_*.py
 
   # If the branch updates documentation, then the docs will need to be updated.
-  publish-docs:
-    if: ${{ github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    defaults:
-      run:
-        shell: bash -l {0}
-    timeout-minutes: 10 # Increased timeout for docs
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          persist-credentials: false
-          fetch-depth: 0
+  # publish-docs:
+  #   if: ${{ github.event_name == 'push' }}
+  #   runs-on: ubuntu-latest
+  #   defaults:
+  #     run:
+  #       shell: bash -l {0}
+  #   timeout-minutes: 10 # Increased timeout for docs
+  #   steps:
+  #     - uses: actions/checkout@v2
+  #       with:
+  #         persist-credentials: false
+  #         fetch-depth: 0
 
-      - name: Cache Conda
-        uses: actions/cache@v3
-        env:
-          CACHE_NUMBER: 1 # Match the build job cache number
-        with:
-          path: ~/conda_pkgs_dir
-          key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
-            hashFiles('conda/dev.yml') }}-docs
+  #     - name: Cache Conda
+  #       uses: actions/cache@v3
+  #       env:
+  #         CACHE_NUMBER: 1 # Match the build job cache number
+  #       with:
+  #         path: ~/conda_pkgs_dir
+  #         key: ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}-${{
+  #           hashFiles('conda/dev.yml') }}-docs
 
-      - name: Build Conda Environment
-        uses: conda-incubator/setup-miniconda@v3
-        with:
-          activate-environment: zppy_interfaces_dev
-          miniforge-variant: Miniforge3
-          miniforge-version: latest
-          environment-file: conda/dev.yml
-          channel-priority: flexible # Changed from strict to flexible
-          auto-update-conda: true
-          python-version: "3.13" # Use stable Python version for docs
+  #     - name: Build Conda Environment
+  #       uses: conda-incubator/setup-miniconda@v3
+  #       with:
+  #         activate-environment: zppy_interfaces_dev
+  #         miniforge-variant: Miniforge3
+  #         miniforge-version: latest
+  #         environment-file: conda/dev.yml
+  #         channel-priority: flexible # Changed from strict to flexible
+  #         auto-update-conda: true
+  #         python-version: "3.13" # Use stable Python version for docs
 
-      - if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true' }}
-        name: Show Conda Environment Info
-        run: |
-          conda config --set anaconda_upload no
-          conda info
-          conda list
+  #     - if: ${{ needs.check-jobs-to-skip.outputs.should_skip != 'true' }}
+  #       name: Show Conda Environment Info
+  #       run: |
+  #         conda config --set anaconda_upload no
+  #         conda info
+  #         conda list
 
-      - name: Install `zppy-interfaces` Package
-        run: pip install .
+  #     - name: Install `zppy-interfaces` Package
+  #       run: pip install .
 
-      # sphinx-multiversion allows for version docs.
-      - name: Build Sphinx Docs
-        run: |
-          cd docs
-          sphinx-multiversion source _build/html
+  #     # sphinx-multiversion allows for version docs.
+  #     - name: Build Sphinx Docs
+  #       run: |
+  #         cd docs
+  #         sphinx-multiversion source _build/html
 
-      - name: Copy Docs and Commit
-        run: |
-          # gh-pages branch must already exist
-          git clone https://github.com/E3SM-Project/zppy-interfaces.git --branch gh-pages --single-branch gh-pages
+  #     - name: Copy Docs and Commit
+  #       run: |
+  #         # gh-pages branch must already exist
+  #         git clone https://github.com/E3SM-Project/zppy-interfaces.git --branch gh-pages --single-branch gh-pages
 
-          # Only replace main docs with latest changes. Docs for tags should be untouched.
-          cd gh-pages
-          rm -r _build/html/main
-          cp -r ../docs/_build/html/main _build/html/main
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
+  #         # Only replace main docs with latest changes. Docs for tags should be untouched.
+  #         cd gh-pages
+  #         rm -r _build/html/main
+  #         cp -r ../docs/_build/html/main _build/html/main
+  #         git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+  #         git config --local user.name "github-actions[bot]"
 
-          # The below command will fail if no changes were present, so we ignore it
-          git add .
-          git commit -m "Update documentation" -a || true
+  #         # The below command will fail if no changes were present, so we ignore it
+  #         git add .
+  #         git commit -m "Update documentation" -a || true
 
-      - name: Push Changes
-        uses: ad-m/github-push-action@master
-        with:
-          branch: gh-pages
-          directory: gh-pages
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          force: true
+  #     - name: Push Changes
+  #       uses: ad-m/github-push-action@master
+  #       with:
+  #         branch: gh-pages
+  #         directory: gh-pages
+  #         github_token: ${{ secrets.GITHUB_TOKEN }}
+  #         force: true


### PR DESCRIPTION
## Summary

Objectives:
- Get GitHub Actions passing when PRs merge into `main`. Based on https://github.com/E3SM-Project/zppy-interfaces/actions, it looks like every time we've merged a PR, the Action fails because there is no `docs` directory. Ultimately of course we want to add docs (#2) but for now we will adjust the workflow `yml`.

Issue resolution:
- Follow-up to #33.

Select one: This pull request is...
- [x] a bug fix: increment the patch version
- [ ] a small improvement: increment the minor version
- [ ] a new feature: increment the minor version
- [ ] an incompatible (non-backwards compatible) API change: increment the major version

## Small Change

- [ ] To merge, I will use "Squash and merge". That is, this change should be a single commit.
- [ ] Logic: I have visually inspected the entire pull request myself.
- [ ] Pre-commit checks: All the pre-commits checks have passed.